### PR TITLE
Add Claude Opus 4.5 support and accept Anthropic canonical model names

### DIFF
--- a/claude_converter.py
+++ b/claude_converter.py
@@ -71,11 +71,37 @@ def get_current_timestamp() -> str:
     return f"{weekday}, {iso_time}"
 
 def map_model_name(claude_model: str) -> str:
-    """Map Claude model name to Amazon Q model ID."""
+    """Map Claude model name to Amazon Q model ID.
+
+    Accepts both short names (e.g., claude-sonnet-4) and canonical names
+    (e.g., claude-sonnet-4-20250514).
+    """
+    DEFAULT_MODEL = "auto"
+
+    # Available models in the service
+    VALID_MODELS = {"auto", "claude-sonnet-4", "claude-sonnet-4.5", "claude-haiku-4.5", "claude-opus-4.5"}
+
+    # Mapping from canonical names to short names
+    CANONICAL_TO_SHORT = {
+        "claude-sonnet-4-20250514": "claude-sonnet-4",
+        "claude-sonnet-4-5-20250929": "claude-sonnet-4.5",
+        "claude-haiku-4-5-20251001": "claude-haiku-4.5",
+        "claude-opus-4-5-20251101": "claude-opus-4.5",
+    }
+
     model_lower = claude_model.lower()
-    if model_lower.startswith("claude-sonnet-4.5") or model_lower.startswith("claude-sonnet-4-5"):
-        return "claude-sonnet-4.5"
-    return "claude-sonnet-4"
+
+    # Check if it's a valid short name
+    if model_lower in VALID_MODELS:
+        return model_lower
+
+    # Check if it's a canonical name
+    if model_lower in CANONICAL_TO_SHORT:
+        return CANONICAL_TO_SHORT[model_lower]
+
+    # Unknown model - log warning and return default
+    logger.warning(f"Unknown model '{claude_model}', falling back to default model '{DEFAULT_MODEL}'")
+    return DEFAULT_MODEL
 
 def extract_text_from_content(content: Union[str, List[Dict[str, Any]]]) -> str:
     """Extract text from Claude content."""

--- a/replicate.py
+++ b/replicate.py
@@ -266,7 +266,7 @@ async def send_chat_request(
         
         if resp.status_code >= 400:
             try:
-                await resp.read()
+                await resp.aread()
                 err = resp.text
             except Exception:
                 err = f"HTTP {resp.status_code}"

--- a/templates/streaming_request.json
+++ b/templates/streaming_request.json
@@ -23,7 +23,7 @@
                                 "currentWorkingDirectory": "C:\\Users\\admin"
                             }
                         },
-                        "origin": "CLI"
+                        "origin": "KIRO_CLI"
                     }
                 }
             ],
@@ -37,7 +37,7 @@
                         },
                         "tools": []
                     },
-                    "origin": "CLI",
+                    "origin": "KIRO_CLI",
                     "modelId": "claude-sonnet-4"
                 }
             },


### PR DESCRIPTION
- Add claude-opus-4.5 to available models
- Accept canonical names with dates (e.g., claude-opus-4-5-20251101)
- Log warning and fall back to 'auto' for unknown models

🤖 Generated with [Claude Code](https://claude.com/claude-code)