### PR TITLE
Update model mapping to reflect Opus support with KIRO_CLI origin

### DIFF
--- a/claude_converter.py
+++ b/claude_converter.py
@@ -78,16 +78,16 @@ def map_model_name(claude_model: str) -> str:
     """
     DEFAULT_MODEL = "claude-sonnet-4.5"
 
-    # Available models in the service (Amazon Q only supports these)
-    VALID_MODELS = {"auto", "claude-sonnet-4", "claude-sonnet-4.5", "claude-haiku-4.5"}
+    # Available models in the service (with KIRO_CLI origin)
+    VALID_MODELS = {"auto", "claude-sonnet-4", "claude-sonnet-4.5", "claude-haiku-4.5", "claude-opus-4.5"}
 
     # Mapping from canonical names to short names
     CANONICAL_TO_SHORT = {
         "claude-sonnet-4-20250514": "claude-sonnet-4",
         "claude-sonnet-4-5-20250929": "claude-sonnet-4.5",
         "claude-haiku-4-5-20251001": "claude-haiku-4.5",
-        # Amazon Q doesn't support Opus - map to Sonnet 4.5 (best available model)
-        "claude-opus-4-5-20251101": "claude-sonnet-4.5",
+        # Amazon Q supports Opus with KIRO_CLI origin
+        "claude-opus-4-5-20251101": "claude-opus-4.5",
         # Legacy Claude 3.5 Sonnet models
         "claude-3-5-sonnet-20241022": "claude-sonnet-4.5",
         "claude-3-5-sonnet-20240620": "claude-sonnet-4.5",


### PR DESCRIPTION
Now that origin is set to KIRO_CLI, Amazon Q supports all Claude models including Opus 4.5. Updated the model mapping to:
- Add claude-opus-4.5 back to VALID_MODELS
- Map claude-opus-4-5-20251101 to claude-opus-4.5 (not Sonnet)
- Update comments to reflect KIRO_CLI origin enables full model support

All Claude models now work natively:
- ✅ claude-sonnet-4
- ✅ claude-sonnet-4.5
- ✅ claude-haiku-4.5
- ✅ claude-opus-4.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)