### PR TITLE
feat: 加入企業組織登入

### DIFF
--- a/app.py
+++ b/app.py
@@ -1271,6 +1271,7 @@ AUTH_SESSIONS: Dict[str, Dict[str, Any]] = {}
 class AuthStartBody(BaseModel):
     label: Optional[str] = None
     enabled: Optional[bool] = True
+    start_url: Optional[str] = None
 
 class AdminLoginRequest(BaseModel):
     password: str
@@ -1353,7 +1354,7 @@ if CONSOLE_ENABLED:
         """
         try:
             cid, csec = await register_client_min()
-            dev = await device_authorize(cid, csec)
+            dev = await device_authorize(cid, csec, start_url=body.start_url)
         except httpx.HTTPError as e:
             raise HTTPException(status_code=502, detail=f"OIDC error: {str(e)}")
 

--- a/auth_flow.py
+++ b/auth_flow.py
@@ -18,7 +18,7 @@ OIDC_BASE = "https://oidc.us-east-1.amazonaws.com"
 REGISTER_URL = f"{OIDC_BASE}/client/register"
 DEVICE_AUTH_URL = f"{OIDC_BASE}/device_authorization"
 TOKEN_URL = f"{OIDC_BASE}/token"
-START_URL = "https://view.awsapps.com/start"
+DEFAULT_START_URL = "https://view.awsapps.com/start"
 
 USER_AGENT = "aws-sdk-rust/1.3.9 os/windows lang/rust/1.87.0"
 X_AMZ_USER_AGENT = "aws-sdk-rust/1.3.9 ua/2.1 api/ssooidc/1.88.0 os/windows lang/rust/1.87.0 m/E app/AmazonQ-For-CLI"
@@ -72,7 +72,7 @@ async def register_client_min() -> Tuple[str, str]:
         return data["clientId"], data["clientSecret"]
 
 
-async def device_authorize(client_id: str, client_secret: str) -> Dict:
+async def device_authorize(client_id: str, client_secret: str, start_url: Optional[str] = None) -> Dict:
     """
     Start device authorization. Returns dict that includes:
     - deviceCode
@@ -84,7 +84,7 @@ async def device_authorize(client_id: str, client_secret: str) -> Dict:
     payload = {
         "clientId": client_id,
         "clientSecret": client_secret,
-        "startUrl": START_URL,
+        "startUrl": start_url or DEFAULT_START_URL,
     }
     proxies = _get_proxies()
     mounts = None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - ./:/app
     restart: unless-stopped
-    command: uvicorn app:app --host 0.0.0.0 --port 8000 --workers 4
+    command: uvicorn app:app --host 0.0.0.0 --port 8000 --workers 1
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/healthz"]
       interval: 30s

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -266,6 +266,7 @@
         <h2>URL 登录（5分钟超时）</h2>
         <div class="row">
           <div class="field"><label>label（可选）</label><input id="auth_label" /></div>
+          <div class="field"><label>Start URL（留空使用个人版；企业版填组织 URL，如 https://your-company.awsapps.com/start）</label><input id="auth_start_url" placeholder="https://view.awsapps.com/start" /></div>
           <div class="field" style="max-width:220px">
             <label>启用（登录成功后新账号是否启用）</label>
             <div>
@@ -757,7 +758,8 @@ async function refreshAccount(id){
  async function startAuth(){
    const body = {
      label: (document.getElementById('auth_label').value || '').trim() || null,
-     enabled: document.getElementById('auth_enabled').checked
+     enabled: document.getElementById('auth_enabled').checked,
+     start_url: (document.getElementById('auth_start_url').value || '').trim() || null,
    };
    try {
      const r = await authFetch(api('/v2/auth/start'), {


### PR DESCRIPTION
## 問題

1. **企業版無法登入** — Start URL 寫死為個人版入口，Amazon Q Enterprise / IAM Identity Center 用戶無法使用。

2. **多 Worker 導致登入失敗** — Auth Session 存在 in-memory，多 worker 下 claim 可能打到不同 process 而回傳 404。

## 變更內容

- 新增可自訂 Start URL，企業版用戶可填入組織入口（如 `https://your-company.awsapps.com/start`）
- 登入介面加入 Start URL 輸入框
- Worker 數改為 1 修復 Session 丟失問題